### PR TITLE
Fix typos in HTML docs

### DIFF
--- a/resources/help/calculations.html
+++ b/resources/help/calculations.html
@@ -95,7 +95,7 @@
    <p> The Command Settings define several commands which are used in the
    submission and control of Q-Chem processes.  Changes to these may be
    required if your system has non-standard paths to common utilities such as
-   the ps command, or if the ouput from the command is non-standard.  
+   the ps command, or if the output from the command is non-standard.  
 
    <p> The Run File Template is the script that is used to run the Q-Chem job
    and can be configured to include, for example, the hostname or start time in
@@ -122,7 +122,7 @@
    <ul>
 	  <li> ${QUEUE}: The name of the PBS queue to which the job is submitted.
 	  <li> ${WALLTIME}: The wall time limit for job.
-	  <li> ${MEMORY}: The virtual memeory limit for the job.
+	  <li> ${MEMORY}: The virtual memory limit for the job.
 	  <li> ${SCRATCH}: The file space limit for the job.
 	  <li> ${NCPUS}: The number of CPUs to use.  Note you will need a parallel
            version of Q-Chem for this option to have any effect.
@@ -143,7 +143,7 @@
 
    <h3><a name="processMonitor"></a>The Process Monitor</h3>
 
-   <p> Once the job has been succesfully submitted, you can monitor its progress
+   <p> Once the job has been successfully submitted, you can monitor its progress
    using the Process Monitor which can be opened via the Calculations&rarr;Job
    Monitor menu option.  
 

--- a/resources/help/layers.html
+++ b/resources/help/layers.html
@@ -86,7 +86,7 @@
    <ul>
       <li> <b>Files:</b> A list of files associated with the molecule that
 		   contain data that can be visualized using IQmol.  These include:
-		   output files (.out), formatted checkpointg files (.fchk) and cube
+		   output files (.out), formatted checkpoint files (.fchk) and cube
 		   files (.cube).  Double clicking a data file brings up a file viewer
            that allows the user to view and search the contents of the file. <br>
 
@@ -98,12 +98,12 @@
 		   See the <a href="surfaces.html">Plotting Surfaces</a> section on how
 		   to generate different types of surfaces.  Configuring a surface
 		   layer allows the user to customise the colors, surface property,
-		   rendering and some of the OpenGL display vairables (e.g.
+		   rendering and some of the OpenGL display variables (e.g.
            transparency).<br>
 
 	  <li> <b>Frequencies:</b> This layer appears when an output file containing
 		   a frequency job is loaded.  See the 
-           <a href="vibrations.html">Vibrational Frequecies</a> section for more
+           <a href="vibrations.html">Vibrational Frequencies</a> section for more
            details.<br>
 
 	  <li> <b>Geometries:</b> This layer appears when an output file containing

--- a/resources/help/modelview.html
+++ b/resources/help/modelview.html
@@ -11,7 +11,7 @@
    <p><center><img src="images/MainWindow.png" /></center></p>
 
    <p> The Model View window provides a hierarchical view of the data
-   strucutures that appear in the Viewer window.  Each molecule is represented
+   structures that appear in the Viewer window.  Each molecule is represented
    as a node or layer in the Model View, and each layer can have child layers
    that can represent atoms, bonds and other associated data.
 

--- a/resources/help/modes.html
+++ b/resources/help/modes.html
@@ -96,7 +96,7 @@
       <li> <B>Right click:</B> Removes atom or bond from selection.
    </ul>
 
-   <p>If the following items are selected, appropriate geometric infomation is
+   <p>If the following items are selected, appropriate geometric information is
    displayed in the bottom left of the viewer window:
 
    <ul>

--- a/resources/help/modes.html
+++ b/resources/help/modes.html
@@ -58,7 +58,7 @@
       <li> <B>Click and drag:</B> If the click originates on an atom, this
 		   will create a bond and a new atom or group.  If the drag occurs
 		   between two existing atoms, then a bond is created (if a bond
-		   already exists then the bond order is incresed). If the click does
+		   already exists then the bond order is increased). If the click does
 		   not originate on an atom, then this action rotates the molecule as
 		   in manipulate mode. <br> 
        <li> <B>Right click:</B> Deletes any atom or bond under the cursor.

--- a/resources/help/overview.html
+++ b/resources/help/overview.html
@@ -32,7 +32,7 @@
    <br>
    <h3><a name="open"></a>Opening Files</h3>
 
-   <p> IQmol's file IO is handled by the OpenBabel libraray which can handle
+   <p> IQmol's file IO is handled by the OpenBabel library which can handle
    many common chemical file formats including the following:
      
    <table cellpadding=4 cellspacing=1>

--- a/resources/help/paths.html
+++ b/resources/help/paths.html
@@ -12,7 +12,7 @@
    the Q-Chem program is supported.
 
    <p> Visualization of the pathway is controlled via the Geometries
-   configruator which can be opened by double clicking the Geometries layer in the
+   configurator which can be opened by double clicking the Geometries layer in the
    Model View.  If the output has been read correctly a window similar to the
    following will appear:
 

--- a/resources/help/surfaces.html
+++ b/resources/help/surfaces.html
@@ -11,7 +11,7 @@
    <h3><a name="modelDensities"></a>Model Densities</h3>
 
    <p> Plotting the true density from molecular orbital coefficients is
-   expensive and the high accuracy is ofen not required for a visual
+   expensive and the high accuracy is often not required for a visual
    representation.  IQmol can generate the following model surfaces without
    having to calculate a wavefunction:
       
@@ -37,13 +37,13 @@
    <p><center><img src="images/SurfaceConfigurator.png" /></center></p>
 
    <p> The colors can be changed by clicking the colored buttons. The render
-   style and opacity can also be changed via the correpsonding controls.
+   style and opacity can also be changed via the corresponding controls.
 
 
    <br>
    <h3><a name="wavefunctionSurfaces"></a>Wavefuction-Based Surfaces</h3>
 
-   <p> If a formmated checkpoint file is available (extension .fchk) then the
+   <p> If a formatted checkpoint file is available (extension .fchk) then the
    following additional surfaces are available.
 
    <ul>
@@ -59,7 +59,7 @@
       <li> Open a checkpoint file either from the menu or by clicking the 
            open button on the Toolbar. <br>
 	  <li> Once the file has loaded the molecule will appear in the Viewer and
-		   the 'Moleculear Orbitals' sub-item will appear in the Model View
+		   the 'Molecular Orbitals' sub-item will appear in the Model View
 		   under the name of the molecule.  Double click the 'Molecular
            Orbitals' item to bring up the add surface dialog.<br>
       <li> Select the required surface and make any necessary changes to the
@@ -75,7 +75,7 @@
            surface can be configured separately.
    </ol>
 
-   <p> Note that the formatted checkpoint file only contains the cannonical
+   <p> Note that the formatted checkpoint file only contains the canonical
    orbitals.  In order to visualize orbitals of other types (e.g. localized
    orbitals), a cube file needs to be generated.
 
@@ -104,7 +104,7 @@
 
    <ol>
       <li> The value selected for the quality of the surface will determine
-           how long it takes to evaulate the grid data.  Each step on the slider
+           how long it takes to evaluate the grid data.  Each step on the slider
            calculates about four times as much data as the previous one, and thus 
            the calculation will take about four times as long.  <br>
       <li> Once the grid data has been generated for a particular property

--- a/resources/help/vibrations.html
+++ b/resources/help/vibrations.html
@@ -8,7 +8,7 @@
    <center> <h1> Vibrational Frequencies <br> </h1> </center><p></p>
  
 
-   <p> IQmol can be used to visualize vibrational frequncies by either
+   <p> IQmol can be used to visualize vibrational frequencies by either
    animation or by displaying the displacement vectors associated with a normal
    mode.  In order to display these, IQmol needs the output from a frequency
    calculation.


### PR DESCRIPTION
Came across these when reading the in-app help. I didn't look at the LaTeX user guide.