### PR TITLE
Also the Grid target depends on autogenerated files in Configurator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ endif (WIN32)
 #)
 
 add_dependencies(Process Configurator)
+add_dependencies(Grid Configurator)
 add_dependencies(Viewer Process)
 
 


### PR DESCRIPTION
Similarly to #2, there are files in Grid that need autogenerated `ui_` files to build. The added interdependence in this PR fixes that problem.