### PR TITLE
Fix missing Amber/ui_ConfigDialog.h

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(Plot)
 add_subdirectory(Process)
 add_subdirectory(Viewer)
 add_subdirectory(Fortran)
+add_subdirectory(Amber)
 
 add_dependencies(Process Configurator)
 add_dependencies(Grid Configurator)


### PR DESCRIPTION
Update CMakeLists.txt to fix Amber/ui_ConfigDialog.h missing mentioned in #25