### PR TITLE
Add CONECT record parsing to PDB parser                     

### DIFF
--- a/src/Data/Geometry.C
+++ b/src/Data/Geometry.C
@@ -37,6 +37,15 @@ namespace Data {
 
 Geometry::Geometry() : m_charge(0), m_multiplicity(1), m_nAlpha(0), m_nBeta(0)  { }
 
+
+void Geometry::addBond(int i, int j)
+{
+   if (i == j) return;
+   if (i > j) { int t = i; i = j; j = t; }
+   QPair<int,int> bond(i, j);
+   if (!m_bonds.contains(bond)) m_bonds.append(bond);
+}
+
 Geometry::Geometry(Geometry const& that) : Base()
 {
    unsigned n(that.nAtoms());

--- a/src/Data/Geometry.h
+++ b/src/Data/Geometry.h
@@ -161,6 +161,13 @@ namespace Data {
          QString const& name() const { return m_name; }
          void name(QString const& name) { m_name = name; }
 
+         // Explicit bond connectivity (0-based atom indices, i < j).
+         // When populated (e.g. from PDB CONECT records) the layer factory
+         // will use these instead of OpenBabel distance-based perception.
+         void addBond(int i, int j);
+         bool hasBonds() const { return !m_bonds.isEmpty(); }
+         QList<QPair<int,int>> const& bonds() const { return m_bonds; }
+
       private:
          unsigned totalNuclearCharge() const;
 
@@ -172,6 +179,7 @@ namespace Data {
          unsigned m_nBeta;
          Bank m_properties;
          QString m_name;
+         QList<QPair<int,int>> m_bonds;
    };
 
 } } // end namespace IQmol::Data

--- a/src/Layer/LayerFactory.C
+++ b/src/Layer/LayerFactory.C
@@ -282,7 +282,8 @@ List Factory::convert(Data::Geometry& geometry)
    OpenBabel::OBMol obMol;
    obMol.BeginModify();
    AtomMap atomMap;
-   
+   QList<OpenBabel::OBAtom*> obAtomList;
+
    for (unsigned i = 0; i < nAtoms; ++i) {
        unsigned Z(geometry.atomicNumber(i));
        qglviewer::Vec position(geometry.position(i));
@@ -295,13 +296,25 @@ List Factory::convert(Data::Geometry& geometry)
        obAtom->SetAtomicNum(Z);
        obAtom->SetVector(position.x, position.y, position.z);
        atomMap.insert(obAtom, atom);
+       obAtomList.append(obAtom);
    }
 
    obMol.SetTotalCharge(geometry.charge());
    obMol.SetTotalSpinMultiplicity(geometry.multiplicity());
    obMol.EndModify();
-   obMol.ConnectTheDots();
-   obMol.PerceiveBondOrders();
+
+   if (geometry.hasBonds()) {
+      for (auto const& b : geometry.bonds()) {
+          if (b.first < obAtomList.size() && b.second < obAtomList.size()) {
+              obMol.AddBond(obAtomList[b.first]->GetIdx(),
+                            obAtomList[b.second]->GetIdx(), 1);
+          }
+      }
+      obMol.PerceiveBondOrders();
+   } else {
+      obMol.ConnectTheDots();
+      obMol.PerceiveBondOrders();
+   }
 
    for (OpenBabel::OBMolBondIter obBond(&obMol); obBond; ++obBond) {
        Atom* begin(atomMap.value(obBond->GetBeginAtom()));

--- a/src/Parser/PdbParser.C
+++ b/src/Parser/PdbParser.C
@@ -185,6 +185,8 @@ bool Pdb::parse(TextStream& textStream)
          QString alternateLocation(line.mid(16, 1).trimmed());
          if (!alternateLocation.isEmpty() && alternateLocation != 'A') continue;
 
+         int serial = line.mid(6, 5).trimmed().toInt();    // atom serial number
+
          QString label(      line.mid(12, 4).trimmed());    // eg. CA
          QString residueName(line.mid(17, 3).trimmed());    // eg. HIS
          QString chainId(    line.mid(21, 1));              // eg. A
@@ -250,12 +252,40 @@ bool Pdb::parse(TextStream& textStream)
                }
             }
             
+            if (serial > 0) {
+               m_serialToAtom.insert(serial, qMakePair(geometry, (int)geometry->nAtoms()));
+            }
             geometry->append(atomSymbol, qv, label);
-         }         
+         }
+
+      }else if (key == "CONECT") {
+         bool ok2;
+         int atom1 = line.mid(6, 5).trimmed().toInt(&ok2);
+         if (!ok2 || atom1 == 0) continue;
+
+         int atom2 = line.mid(11, 5).trimmed().toInt(&ok2);
+         if (ok2 && atom2 > 0) m_conectPairs.append(qMakePair(atom1, atom2));
+
+         int atom3 = line.mid(16, 5).trimmed().toInt(&ok2);
+         if (ok2 && atom3 > 0) m_conectPairs.append(qMakePair(atom1, atom3));
+
+         int atom4 = line.mid(21, 5).trimmed().toInt(&ok2);
+         if (ok2 && atom4 > 0) m_conectPairs.append(qMakePair(atom1, atom4));
+
+         int atom5 = line.mid(26, 5).trimmed().toInt(&ok2);
+         if (ok2 && atom5 > 0) m_conectPairs.append(qMakePair(atom1, atom5));
 
       }else if (key == "ENDMDL" || key == "END") {
             break;
-      } 
+      }
+   }
+
+   for (auto const& pair : m_conectPairs) {
+      auto it1 = m_serialToAtom.find(pair.first);
+      auto it2 = m_serialToAtom.find(pair.second);
+      if (it1 == m_serialToAtom.end() || it2 == m_serialToAtom.end()) continue;
+      if (it1->first != it2->first) continue;  // skip cross-geometry bonds
+      it1->first->addBond(it1->second, it2->second);
    }
 
    if (!setSecondaryStructure()) {

--- a/src/Parser/PdbParser.h
+++ b/src/Parser/PdbParser.h
@@ -28,6 +28,8 @@
 #include "Parser.h"
 #include "Data/PdbData.h"
 #include "Data/Residue.h"
+#include <QMap>
+#include <QPair>
 #include <QVector>
 
 
@@ -67,8 +69,12 @@ namespace Parser {
          // Need these to keep the order of the pdb
          QList<QChar> m_chainOrder;
          QList<QString> m_geometryOrder;
-         
-		 // Scatters the interval-based SS specifications read from the 
+
+         // CONECT record support: maps PDB atom serial → (geometry, 0-based index)
+         QMap<int, QPair<Data::Geometry*, int>> m_serialToAtom;
+         QList<QPair<int,int>> m_conectPairs;
+
+		 // Scatters the interval-based SS specifications read from the
          // PDB to one type per residue
          bool setSecondaryStructure();
          bool saveSecondaryStructure();


### PR DESCRIPTION
                                                                                                                                                             
                                                                                                                                                                                                                                             
  ### Summary                                                                                                                                                                                                                                  
   
  - Parse `CONECT` records in PDB files to extract explicit bond connectivity for HETATM molecules (ligands, cofactors, etc.)                                                                                                                  
  - Store explicit bonds on `Data::Geometry` and use them in the layer factory instead of OpenBabel distance-based bond perception
  - Deduplicate symmetric CONECT entries (PDB specifies each bond in both directions)                                                                                                                                                          
                                                                                                                                                                                                                                               
  ### Problem                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                               
  The PDB parser ignored `CONECT` records entirely. Bond connectivity for ligands and non-protein HETATM molecules was inferred purely from interatomic distances via OpenBabel's `ConnectTheDots`. This produces incorrect bond orders and    
  topologies for metal complexes, unusual geometries, and molecules where distance alone is ambiguous.
                                                                                                                                                                                                                                               
  ### Changes                                               

  **`src/Data/Geometry.h` / `Geometry.C`**                                                                                                                                                                                                     
  - Added `addBond(int i, int j)` — stores a normalised (i < j), deduplicated bond by 0-based atom index
  - Added `hasBonds()` and `bonds()` accessors                                                                                                                                                                                                 
                                                            
  **`src/Parser/PdbParser.h`**                                                                                                                                                                                                                 
  - Added `m_serialToAtom`: maps PDB atom serial number → `(Geometry*, atom index)` for HETATM atoms
  - Added `m_conectPairs`: accumulates raw serial-number pairs from CONECT lines                                                                                                                                                               
   
  **`src/Parser/PdbParser.C`**                                                                                                                                                                                                                 
  - Parses atom serial number (cols 7–11) for each ATOM/HETATM record
  - Records the serial→atom mapping before appending each non-water HETATM atom                                                                                                                                                                
  - New `CONECT` branch collects up to four bonded serials per line
  - After the main parse loop, resolves serial pairs into `Geometry::addBond` calls; cross-geometry bonds (e.g. protein–ligand) are skipped as they cannot be represented in the current layer model                                           
                                                                                                                                                                                                                                               
  **`src/Layer/LayerFactory.C`**                                                                                                                                                                                                               
  - When `geometry.hasBonds()`, adds explicit OB bonds and calls `PerceiveBondOrders` only (skips `ConnectTheDots`)                                                                                                                            
  - Falls back to the existing distance-based perception when no explicit bonds are present                                                                                                                                                    
   
  ### Limitations / Future Work                                                                                                                                                                                                                
                                                            
  - CONECT records that reference `ATOM` serial numbers (e.g. disulfide bonds) are not yet resolved — protein chain atoms are not tracked in `m_serialToAtom`                                                                                  
  - Cross-geometry bonds (protein–ligand covalent attachments) are silently ignored
  - Bond order from CONECT is not encoded (PDB format does not carry it); OpenBabel's `PerceiveBondOrders` is still used to assign orders once topology is fixed          